### PR TITLE
Fix php instructions formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Você tem duas opções para instalar a ferramenta:
 2. **Usando PHP no Terminal**: Se você já tem o PHP configurado como variável de ambiente, navegue até a pasta do projeto e execute:
    ```bash
    php -S localhost:8000
+   ```
 3. **Apache ou NGINX**
 ## Funcionalidades da Consulta
 


### PR DESCRIPTION
## Summary
- close the php terminal command block
- move the Apache/NGINX option outside the code block

## Testing
- `php -l api/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848442f72d8832e97f46a14e2c0fb50